### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -237,6 +237,8 @@ jobs:
     name: Update Changelog
     needs: [create-release, build-and-upload-assets, build-flatpak]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/securebitsorg/Bash-Script-Maker/security/code-scanning/11](https://github.com/securebitsorg/Bash-Script-Maker/security/code-scanning/11)

The recommended fix is to add an explicit `permissions:` block to the `update-changelog` job in `.github/workflows/auto-release.yml`. Since this job pushes changes to the repository (`git push`), it requires `contents: write` permission. Other permissions can and should remain unset unless needed; this minimizes potential risks. The edit consists of adding a few lines defining `permissions:` directly under the job definition (`update-changelog:`). No other changes are necessary. We will only change the area around line 237 (`name: Update Changelog`), for the job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
